### PR TITLE
Fix`URLBuilder.appendRelativePath` to work correctly

### DIFF
--- a/ksoup/src/commonMain/kotlin/com/fleeksoft/ksoup/ported/Extensions.kt
+++ b/ksoup/src/commonMain/kotlin/com/fleeksoft/ksoup/ported/Extensions.kt
@@ -71,6 +71,10 @@ internal fun URLBuilder.appendRelativePath(relativePath: String): URLBuilder {
             }
 
             ".." -> {
+                // Clean up last path if exist
+                if (index == 0 && !isLastSlash) {
+                    segments.removeLastOrNull()
+                }
                 if (segments.isNotEmpty()) {
                     segments.removeLast()
                 }

--- a/ksoup/src/commonTest/kotlin/com/fleeksoft/ksoup/internal/StringUtilTest.kt
+++ b/ksoup/src/commonTest/kotlin/com/fleeksoft/ksoup/internal/StringUtilTest.kt
@@ -137,6 +137,8 @@ class StringUtilTest {
         assertEquals("https://example2.com/one", StringUtil.resolve("http://example.com/", "https://example2.com/one"))
         assertEquals("https://example.com/one", StringUtil.resolve("wrong", "https://example.com/one"))
         assertEquals("https://example.com/one", StringUtil.resolve("https://example.com/one", ""))
+        assertEquals("https://example.com/one/two.c", StringUtil.resolve("https://example.com/one/two/", "../two.c"))
+        assertEquals("https://example.com/two.c", StringUtil.resolve("https://example.com/one/two", "../two.c"))
         assertEquals("", StringUtil.resolve("wrong", "also wrong"))
         assertEquals("ftp://example.com/one", StringUtil.resolve("ftp://example.com/two/", "../one"))
         assertEquals("ftp://example.com/one/two.c", StringUtil.resolve("ftp://example.com/one/", "./two.c"))


### PR DESCRIPTION
Fixed an issue with resolving relative Urls.

`StringUtil.resolve("https://example.com/one/two", "../two.c")`

Current version of ksoup returns `https://example.com/one/two.c`

But, it should be `https://example.com/two.c`