### PR TITLE
disable test for windows unsupported charsets

### DIFF
--- a/ksoup-test/test/com/fleeksoft/ksoup/helper/DataUtilTest.kt
+++ b/ksoup-test/test/com/fleeksoft/ksoup/helper/DataUtilTest.kt
@@ -183,7 +183,7 @@ class DataUtilTest {
         assertTrue(doc.title().contains("UTF-16LE"))
         assertTrue(doc.text().contains("가각갂갃간갅"))
 
-        if (Platform.isJS()) {
+        if (Platform.isJS() || Platform.isWindows()) {
             // FIXME: UTF-32 charset not supported
             return@runTest
         }
@@ -216,7 +216,7 @@ class DataUtilTest {
         assertTrue(doc.title().contains("UTF-16LE"))
         assertTrue(doc.text().contains("가각갂갃간갅"))
 
-        if (Platform.isJS()) {
+        if (Platform.isJS() || Platform.isWindows()) {
             // FIXME: UTF-32 charset not supported
             return@runTest
         }

--- a/ksoup-test/test/com/fleeksoft/ksoup/integration/ParseTest.kt
+++ b/ksoup-test/test/com/fleeksoft/ksoup/integration/ParseTest.kt
@@ -21,8 +21,8 @@ import kotlin.test.assertTrue
 class ParseTest {
     @Test
     fun testHtml5Charset() = runTest {
-        if (Platform.isApple()) {
-//            apple don't support gb2312 or gbk
+        if (Platform.isApple() || Platform.isWindows()) {
+//            don't support gb2312 or gbk
             return@runTest
         }
         // test that <meta charset="gb2312"> works


### PR DESCRIPTION
utf-32 and gbk not supported