### PR TITLE
chore: deprecate Korlibs-based network and parsing extensions

### DIFF
--- a/ksoup-korlibs/src/com/fleeksoft/ksoup/KsoupExt.kt
+++ b/ksoup-korlibs/src/com/fleeksoft/ksoup/KsoupExt.kt
@@ -19,6 +19,7 @@ import korlibs.io.stream.SyncStream
  * @param parser alternate [parser][Parser.xmlParser] to use.
  * @return sane HTML
  */
+@Deprecated("Korlibs support is deprecated; use the ksoup-kotlinx variant instead.")
 public suspend fun Ksoup.parseFile(
     filePath: String,
     baseUri: String = filePath,
@@ -33,6 +34,7 @@ public suspend fun Ksoup.parseFile(
     )
 }
 
+@Deprecated("Korlibs support is deprecated; use the ksoup-kotlinx variant instead.")
 public suspend fun Ksoup.parseFile(
     file: VfsFile,
     baseUri: String = file.absolutePath,
@@ -47,6 +49,7 @@ public suspend fun Ksoup.parseFile(
     )
 }
 
+@Deprecated("Korlibs support is deprecated; use the ksoup-kotlinx variant instead.")
 public fun Ksoup.parseStream(
     stream: SyncStream,
     baseUri: String = "",

--- a/ksoup-network-korlibs/src/com/fleeksoft/ksoup/network/KsoupNetwork.kt
+++ b/ksoup-network-korlibs/src/com/fleeksoft/ksoup/network/KsoupNetwork.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.withContext
  * @return sane HTML
  *
  */
+@Deprecated("Korlibs support is deprecated; use the ktor3 variant `ksoup-network` instead.")
 public suspend fun Ksoup.parseGetRequest(
     url: String,
     headers: Map<String, String> = emptyMap(),
@@ -48,6 +49,7 @@ public suspend fun Ksoup.parseGetRequest(
  * @return sane HTML
  *
  */
+@Deprecated("Korlibs support is deprecated; use the ktor3 variant `ksoup-network` instead.")
 public suspend fun Ksoup.parseSubmitRequest(
     url: String,
     params: Map<String, String> = emptyMap(),
@@ -77,6 +79,7 @@ public suspend fun Ksoup.parseSubmitRequest(
  * @return sane HTML
  *
  */
+@Deprecated("Korlibs support is deprecated; use the ktor3 variant `ksoup-network` instead.")
 public suspend fun Ksoup.parsePostRequest(
     url: String,
     body: HttpBodyContent = HttpBodyContent("", ""),


### PR DESCRIPTION
Add @Deprecated annotations to:
- `Ksoup.parseGetRequest`, `parseSubmitRequest`, and `parsePostRequest` in ksoup-network-korlibs
- `Ksoup.parseFile` and `Ksoup.parseStream` in ksoup-korlibs

Recommend using the ktor3-based `ksoup-network` variant for HTTP APIs and the `ksoup-kotlinx` variant for file and stream parsing.